### PR TITLE
[REFACTOR] 회원가입시 메일 인증 로직 수정

### DIFF
--- a/src/v1/apis/auth/services/auth.service.ts
+++ b/src/v1/apis/auth/services/auth.service.ts
@@ -24,12 +24,16 @@ export default class AuthService {
     nickname,
     mailVerificationCode,
   }: TypeOf<typeof signupInputSchema>): Promise<TypeOf<typeof signupResponseSchema>> {
-    await this.mailVerificationService.verifyEmailCode(email, mailVerificationCode);
+    const { emailCodeId } = await this.mailVerificationService.verifyEmailCode(
+      email,
+      mailVerificationCode,
+    );
     await this.userService.createUser({
       email,
       password,
       nickname,
     });
+    await this.mailVerificationService.expireEmailCode(emailCodeId);
 
     return {
       status: STATUS.SUCCESS,

--- a/src/v1/apis/auth/services/mail-verification.service.ts
+++ b/src/v1/apis/auth/services/mail-verification.service.ts
@@ -48,7 +48,7 @@ export default class MailVerificationService {
     };
   }
 
-  async verifyEmailCode(email: string, code: string) {
+  async verifyEmailCode(email: string, code: string): Promise<{ emailCodeId: number }> {
     const verification = await this.mailVerificationRepository.findFirstByEmail(email);
     if (!verification) {
       throw new NotFoundException('Verification code not found.');
@@ -64,7 +64,11 @@ export default class MailVerificationService {
       throw new UnAuthorizedException('Invalid verification code.');
     }
 
-    await this.mailVerificationRepository.update(verification.id, { status: 'VERIFIED' });
+    return { emailCodeId: verification.id };
+  }
+
+  async expireEmailCode(id: number) {
+    await this.mailVerificationRepository.update(id, { status: 'VERIFIED' });
   }
 
   private generateVerificationCode(length: number = 6): string {

--- a/src/v1/apis/auth/services/user.service.ts
+++ b/src/v1/apis/auth/services/user.service.ts
@@ -12,7 +12,9 @@ export default class UserService {
   constructor(private httpClient: GotClient) {}
 
   async createUser(userData: TypeOf<typeof createUserInputSchema>) {
-    const response = await this.httpClient.request({
+    const response = await this.httpClient.request<{
+      message: string;
+    }>({
       method: 'POST',
       url: `http://${process.env.USER_SERVER_URL}/api/v1/users`,
       headers: {
@@ -25,7 +27,7 @@ export default class UserService {
       },
     });
     if (response.statusCode !== 201) {
-      throw new HttpException(response.statusCode, '유저 생성에 실패했습니다.');
+      throw new HttpException(response.statusCode, response.body.message);
     }
   }
 
@@ -41,7 +43,6 @@ export default class UserService {
     if (response.statusCode !== 200) {
       throw new UnAuthorizedException('Invalid credentials.');
     }
-    console.log(response);
     return response.body.data.userId;
   }
 

--- a/test/v1/apis/auth/mail-verification.service.spec.ts
+++ b/test/v1/apis/auth/mail-verification.service.spec.ts
@@ -111,19 +111,4 @@ describe('이메일 인증 확인', () => {
 
     expect(mailVerificationRepository.update).toHaveBeenCalledWith(1, { tryCount: 2 });
   });
-
-  it('정상 인증 → VERIFIED 처리', async () => {
-    mailVerificationRepository.findFirstByEmail = vi.fn().mockResolvedValue({
-      id: 1,
-      code: '123456',
-      expiresAt: new Date(Date.now() + 1000 * 60),
-      tryCount: 0,
-    });
-
-    mailVerificationRepository.update = vi.fn().mockResolvedValue(undefined);
-
-    await mailVerificationService.verifyEmailCode(email, '123456');
-
-    expect(mailVerificationRepository.update).toHaveBeenCalledWith(1, { status: 'VERIFIED' });
-  });
 });


### PR DESCRIPTION
## 📝 작업 내용

- 회원가입시 메일인증 로직을 변경하였습니다.
- 유저생성시 닉네임 중복이 있을 경우 정상적으로 유저가 생성되지 않아도 이메일 인증코드가 만료되서 다시 인증코드를 전송해야하는 수고가 생길 수 있었습니다.
- 따라서 정상적으로 유저가 생성 된다면 이메일 인증 코드를 만료시켰습니다.