### PR TITLE
[REFACTOR] 내부API 보안 설정

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -67,4 +67,13 @@ function setDecorate(fastify: FastifyInstance) {
       });
     }
   });
+
+  fastify.decorate('internalOnly', async (request: FastifyRequest, reply: FastifyReply) => {
+    if (!request.internal) {
+      return reply.status(403).send({
+        status: STATUS.ERROR,
+        message: 'Forbidden',
+      });
+    }
+  });
 }

--- a/src/plugins/router.ts
+++ b/src/plugins/router.ts
@@ -4,6 +4,7 @@ import { FastifyInstance } from 'fastify/types/instance.js';
 // 권한 필요 여부를 표현할 때 추가 옵션 타입 확장
 interface RouteOptions extends RouteShorthandOptions {
   auth?: boolean; // 권한 필요 여부 (옵셔널)
+  internalOnly?: boolean; // 내부 API 여부 (옵셔널)
   description?: string; // 설명 (옵셔널)
 }
 
@@ -20,6 +21,17 @@ export async function addRoutes(fastify: FastifyInstance, routes: Route[]) {
       route.method === '*'
         ? ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD']
         : [route.method];
+
+    if (route.options.internalOnly === true) {
+      fastify.route({
+        method,
+        url: route.url,
+        handler: route.handler,
+        schema: route.options.schema,
+        onRequest: fastify.internalOnly,
+      });
+      return;
+    }
 
     // 권한 필요 없으면 그대로 등록
     if (route.options.auth === false) {

--- a/src/v1/apis/auth/auth.route.ts
+++ b/src/v1/apis/auth/auth.route.ts
@@ -102,6 +102,7 @@ export default async function authRoutes(fastify: FastifyInstance) {
           },
         },
         auth: false,
+        internalOnly: true,
       },
     },
     {

--- a/src/v1/apis/auth/services/auth.service.ts
+++ b/src/v1/apis/auth/services/auth.service.ts
@@ -24,12 +24,16 @@ export default class AuthService {
     nickname,
     mailVerificationCode,
   }: TypeOf<typeof signupInputSchema>): Promise<TypeOf<typeof signupResponseSchema>> {
-    await this.mailVerificationService.verifyEmailCode(email, mailVerificationCode);
+    const { emailCodeId } = await this.mailVerificationService.verifyEmailCode(
+      email,
+      mailVerificationCode,
+    );
     await this.userService.createUser({
       email,
       password,
       nickname,
     });
+    await this.mailVerificationService.expireEmailCode(emailCodeId);
 
     return {
       status: STATUS.SUCCESS,

--- a/src/v1/apis/auth/services/mail-verification.service.ts
+++ b/src/v1/apis/auth/services/mail-verification.service.ts
@@ -48,7 +48,7 @@ export default class MailVerificationService {
     };
   }
 
-  async verifyEmailCode(email: string, code: string) {
+  async verifyEmailCode(email: string, code: string): Promise<{ emailCodeId: number }> {
     const verification = await this.mailVerificationRepository.findFirstByEmail(email);
     if (!verification) {
       throw new NotFoundException('Verification code not found.');
@@ -64,7 +64,11 @@ export default class MailVerificationService {
       throw new UnAuthorizedException('Invalid verification code.');
     }
 
-    await this.mailVerificationRepository.update(verification.id, { status: 'VERIFIED' });
+    return { emailCodeId: verification.id };
+  }
+
+  async expireEmailCode(id: number) {
+    await this.mailVerificationRepository.update(id, { status: 'VERIFIED' });
   }
 
   private generateVerificationCode(length: number = 6): string {

--- a/src/v1/apis/auth/services/user.service.ts
+++ b/src/v1/apis/auth/services/user.service.ts
@@ -12,7 +12,9 @@ export default class UserService {
   constructor(private httpClient: GotClient) {}
 
   async createUser(userData: TypeOf<typeof createUserInputSchema>) {
-    const response = await this.httpClient.request({
+    const response = await this.httpClient.request<{
+      message: string;
+    }>({
       method: 'POST',
       url: `http://${process.env.USER_SERVER_URL}/api/v1/users`,
       headers: {
@@ -25,7 +27,7 @@ export default class UserService {
       },
     });
     if (response.statusCode !== 201) {
-      throw new HttpException(response.statusCode, '유저 생성에 실패했습니다.');
+      throw new HttpException(response.statusCode, response.body.message);
     }
   }
 
@@ -41,7 +43,6 @@ export default class UserService {
     if (response.statusCode !== 200) {
       throw new UnAuthorizedException('Invalid credentials.');
     }
-    console.log(response);
     return response.body.data.userId;
   }
 

--- a/src/v1/common/types/fastify.d.ts
+++ b/src/v1/common/types/fastify.d.ts
@@ -3,6 +3,7 @@ import 'fastify';
 declare module 'fastify' {
   interface FastifyInstance {
     authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    internalOnly: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
   }
 
   interface FastifyRequest {

--- a/src/v1/common/types/fastify.d.ts
+++ b/src/v1/common/types/fastify.d.ts
@@ -11,6 +11,7 @@ declare module 'fastify' {
       'X-User-Id': string | undefined;
     };
 
+    internal: boolean;
     authenticated: boolean;
     userId: number;
   }

--- a/test/v1/apis/auth/mail-verification.service.spec.ts
+++ b/test/v1/apis/auth/mail-verification.service.spec.ts
@@ -111,19 +111,4 @@ describe('이메일 인증 확인', () => {
 
     expect(mailVerificationRepository.update).toHaveBeenCalledWith(1, { tryCount: 2 });
   });
-
-  it('정상 인증 → VERIFIED 처리', async () => {
-    mailVerificationRepository.findFirstByEmail = vi.fn().mockResolvedValue({
-      id: 1,
-      code: '123456',
-      expiresAt: new Date(Date.now() + 1000 * 60),
-      tryCount: 0,
-    });
-
-    mailVerificationRepository.update = vi.fn().mockResolvedValue(undefined);
-
-    await mailVerificationService.verifyEmailCode(email, '123456');
-
-    expect(mailVerificationRepository.update).toHaveBeenCalledWith(1, { status: 'VERIFIED' });
-  });
 });


### PR DESCRIPTION
## 🔗 반영 브랜치

[refactor/내부API-보안-설정](https://github.com/42-Gang/auth-server/compare/dev...refactor/%EB%82%B4%EB%B6%80API-%EB%B3%B4%EC%95%88-%EC%84%A4%EC%A0%95?expand=1) -> dev

## 📝 작업 내용

내부에서만 사용되는 API의 보안설정을 하였습니다.