### PR TITLE
[FIX] refreshToken 쿠키 path 수정

### DIFF
--- a/src/v1/apis/oauth/oauth.controller.ts
+++ b/src/v1/apis/oauth/oauth.controller.ts
@@ -35,9 +35,10 @@ export default class OAuthController {
     const { accessToken, refreshToken, refreshTokenExpiresAt } = await service.handleCallback(body);
 
     reply.setCookie('refreshToken', refreshToken, {
+      path: '/api/v1/auth',
       httpOnly: true,
       secure: true,
-      sameSite: 'strict',
+      sameSite: 'none',
       expires: refreshTokenExpiresAt,
     });
 


### PR DESCRIPTION
## 📝 작업 내용

- oauth를 통해 로그인시 refresh token의 path가 `/api/v1/oauth/..` 로 되어 있었습니다.
- 이를 `/api/v1/auth`로 변경하였습니다.